### PR TITLE
EIP domain name fix for networking lab

### DIFF
--- a/lab-networking/Step_1_Setup.yaml
+++ b/lab-networking/Step_1_Setup.yaml
@@ -147,7 +147,7 @@ Resources:
   EIP:
     Type: AWS::EC2::EIP
     Properties:
-      Domain: VPC
+      Domain: vpc
       InstanceId:
         Ref: WebServerInstance
 Outputs:

--- a/lab-networking/Step_2_LaFours_Disaster.yaml
+++ b/lab-networking/Step_2_LaFours_Disaster.yaml
@@ -157,7 +157,7 @@ Resources:
   EIP:
     Type: AWS::EC2::EIP
     Properties:
-      Domain: VPC
+      Domain: vpc
       InstanceId:
         Ref: WebServerInstance
 Outputs:


### PR DESCRIPTION
According to the [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html)  EIP Domain Allowed Values are: standard | vpc

Current value "VPC" fails to create the EIP resource